### PR TITLE
fix: read tsm and write openGemini, parse fail, point without fields is unsupported

### DIFF
--- a/src/dataMigrate.go
+++ b/src/dataMigrate.go
@@ -21,6 +21,7 @@ import (
     "sort"
     "strings"
     "time"
+    "bytes"
 
     "github.com/influxdata/influxdb/pkg/escape"
     "github.com/influxdata/influxdb/tsdb/engine/tsm1"
@@ -178,6 +179,20 @@ func (cmd *DataMigrateCommand) writeTsmFiles(files []string) error {
     }
     return nil
 }
+func (cmd * DataMigrateCommand) formatespace (buf string) string {
+    var b bytes.Buffer
+    i := 0
+    for i < len(buf) {
+        if buf[i] == ' ' {
+            b.WriteByte('\\')
+            b.WriteByte(' ')
+        } else {
+	    b.WriteByte(buf[i])
+        }
+	i++
+    }
+    return b.String()
+}
 
 func (cmd *DataMigrateCommand) writeValues(seriesKey []byte, field string, values []tsm1.Value) error {
     c, err := client.NewHTTPClient(client.HTTPConfig{
@@ -203,7 +218,8 @@ func (cmd *DataMigrateCommand) writeValues(seriesKey []byte, field string, value
 	    continue
 	}
 	tag_key_values := strings.Split(key_value,"=")
-	tags[tag_key_values[0]]=tag_key_values[1]
+	tag_key_value := cmd.formatespace(tag_key_values[1])
+	tags[tag_key_values[0]]=tag_key_value
     }
     
     fields := map[string]interface{}{}


### PR DESCRIPTION
fix #1 

The tag key value in the TSM file contains spaces and transfer characters. After the tag key value is written into the InfluxDB, it is found that the tag key value contains backslashes (\).
```
> select * from alerts
name: alerts
time                alertExpr        alertID                                     fieldName level   subsystemTag
----                ---------        -------                                     --------- -----   ------------
1657861283000000000 TMK335-*** X    SWOrbitControlApp-TMK335-***\ X-WARNING      TMK335    WARNING  姿轨控
```
so, why dataMigrate insert data to openGemini is wrong?
 
**In the tag key value data “SWOrbitControlApp-TMK335-***\ X-WARNING”, a character '\\' is missing before the space. After the character is added, the result is correct.**

insert the tsm file data to openGemini var dataMigrate
```
> select * from alerts
name: alerts
time                alertExpr        alertID                                     fieldName level   subsystemTag
----                ---------        -------                                     --------- -----   ------------
1657861283000000000 TMK335-*** X     SWOrbitControlApp-TMK335-***\ X-WARNING     TMK335    WARNING  姿轨控
```