### PR TITLE
feat: add abundant log information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+logs

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Usage: dataMigrate [flags]
     	Optional: the retention policy to read (requires -database)
   -start string
     	Optional: the start time to read (RFC3339 format)
+  -mode string
+      Optional: whether to enable debug log or not (set as "Debug" to enable it)
   -to string
     	Destination host to write data to (default "127.0.0.1:8086",which is the openGemini service default address)
 ```

--- a/src/cursor.go
+++ b/src/cursor.go
@@ -15,7 +15,6 @@ copyright 2023 Qizhi Huang(flaggyellow@qq.com)
 package main
 
 import (
-    "fmt"
     "math"
     "sort"
     "time"
@@ -58,8 +57,19 @@ func (c *Cursor) init() error {
         }
     }
     c.readTs = c.seeks[0].readMax
+    if logger.IsDebug() {
+        // check the validation of readMax
+        for i := 1; i < len(c.seeks); i++ {
+            if c.seeks[i].readMax < c.seeks[i-1].readMax {
+                logger.LogString("Cursor.init: found readMax not in right order", TOLOGFILE, LEVEL_DEBUG)
+            }
+        }
+    }
     var err error
     c.buf, err = c.readBlock()
+    if err != nil {
+        logger.LogString("Read block failed: "+err.Error(), TOLOGFILE, LEVEL_ERROR)
+    }
     c.pos = 0
     return err
 }
@@ -68,6 +78,13 @@ func (c *Cursor) readBlock() (tsm1.Values, error) {
     // No matching blocks to decode
     if len(c.seeks) == 0 || c.readTs >= c.et {
         return nil, nil
+    }
+
+    // check the validation of readTs
+    if logger.IsDebug() {
+        if c.readTs > c.seeks[0].readMax {
+            logger.LogString("Cursor.readBlock: readTs > c.seeks[0].readMax", TOLOGFILE, LEVEL_DEBUG)
+        }
     }
 
     var locsToRead []*location
@@ -91,8 +108,30 @@ func (c *Cursor) readBlock() (tsm1.Values, error) {
     if len(c.seeks) > len(locsToRead) {
         nextRoundStartTs := c.seeks[len(locsToRead)].readMax
         if nextRoundStartTs <= upperBound {
-            upperBound = nextRoundStartTs - 1
+            upperBound = nextRoundStartTs
         }
+    }
+
+    // this should not happen
+    if upperBound <= c.readTs {
+        logger.LogString("Cursor.readBlock: found upperBound <= readTs", TOLOGFILE, LEVEL_ERROR)
+        // resolve the problem
+        sort.Slice(c.seeks, func(i, j int) bool {
+            return c.seeks[i].readMax < c.seeks[j].readMax
+        })
+        for i := 0; i < len(c.seeks); i++ {
+            rm := c.seeks[i].readMax
+            if rm < c.readTs {
+                logger.LogString("Cursor.readBlock: found readMax < readTs", TOLOGFILE, LEVEL_DEBUG)
+                c.seeks[i].readMax = c.readTs
+                rm = c.readTs
+            }
+            if rm >= c.et || rm >= c.seeks[i].entry.MaxTime {
+                c.seeks = append(c.seeks[:i], c.seeks[i+1:]...)
+                i--
+            }
+        }
+        return c.readBlock()
     }
 
     var buf []tsm1.Value
@@ -101,11 +140,12 @@ func (c *Cursor) readBlock() (tsm1.Values, error) {
         tombstones := e.r.TombstoneRange(c.key)
         values, err := e.r.(*tsm1.TSMReader).ReadAt(&e.entry, nil)
         if err != nil {
+            logger.LogString("Read block failed: "+err.Error(), TOLOGFILE, LEVEL_ERROR)
             return nil, err
         }
         for _, v := range values {
             ts := v.UnixNano()
-            if ts < c.readTs {
+            if ts <= c.readTs {
                 continue
             }
             if ts > upperBound {
@@ -134,7 +174,8 @@ func (c *Cursor) readBlock() (tsm1.Values, error) {
     c.readTs = upperBound
 
     if len(buf) <= 0 {
-        return c.readBlock()
+        logger.LogString("Cursor.readBlock: the buffer is empty", TOLOGFILE|TOCONSOLE, LEVEL_ERROR)
+        return nil, nil
     }
 
     return sortAndDeduplicateValues(&buf), nil
@@ -176,6 +217,10 @@ func (c *Cursor) next() (tsm1.Value, error) {
 // referenced from https://github.com/influxdata/influxdb/tree/v1.8.2/tsdb/engine/tsm1/encoding.gen.go
 // function (Values).Deduplicate
 func sortAndDeduplicateValues(buf *[]tsm1.Value) []tsm1.Value {
+    if len(*buf) == 0 {
+        logger.LogString("sortAndDeduplicateValues: empty buffer", TOLOGFILE, LEVEL_DEBUG)
+        return nil
+    }
     sort.Slice(*buf, func(i, j int) bool {
         return (*buf)[i].UnixNano() < (*buf)[j].UnixNano()
     })
@@ -196,7 +241,7 @@ type Scanner struct {
     fields      map[string]*Cursor
 }
 
-func (s *Scanner) nextPoint() (*client.Point, error) {
+func (s *Scanner) nextPoint(cmd *DataMigrateCommand) (*client.Point, error) {
     // determine the current timestamp
     var curTs int64 = math.MaxInt64
     for _, cursor := range s.fields {
@@ -233,6 +278,16 @@ func (s *Scanner) nextPoint() (*client.Point, error) {
         }
     }
 
+    // statistics
+    for t := range s.tags {
+        cmd.stat.tagsRead[s.measurement+t] = struct{}{}
+        cmd.stat.tagsTotal[s.measurement+t] = struct{}{}
+    }
+    for f := range fields {
+        cmd.stat.fieldsRead[s.measurement+f] = struct{}{}
+        cmd.stat.fieldTotal[s.measurement+f] = struct{}{}
+    }
+
     return client.NewPoint(s.measurement, s.tags, fields, time.Unix(0, curTs))
 }
 
@@ -249,19 +304,21 @@ func (s *Scanner) writeBatches(c client.Client, cmd *DataMigrateCommand) error {
             flag = false
         }
 
-        pt, err := s.nextPoint()
+        pt, err := s.nextPoint(cmd)
 
         if err != nil {
-            fmt.Fprintf(cmd.Stdout, "point read error: %v", err)
+            logger.LogString("point read error: "+err.Error(), TOLOGFILE|TOCONSOLE, LEVEL_ERROR)
             return err
         }
 
         if pt == nil {
+            rowsNum := len(bp.Points())
             err := c.Write(bp)
             if err != nil {
-                fmt.Fprintf(cmd.Stdout, "insert error: %v", err)
+                logger.LogString("insert error: "+err.Error(), TOLOGFILE|TOCONSOLE, LEVEL_ERROR)
                 return err
             }
+            cmd.stat.rowsRead += rowsNum
             break
         }
 
@@ -270,9 +327,10 @@ func (s *Scanner) writeBatches(c client.Client, cmd *DataMigrateCommand) error {
         if count == BATCHSIZE {
             err := c.Write(bp)
             if err != nil {
-                fmt.Fprintf(cmd.Stdout, "insert error: %v", err)
+                logger.LogString("insert error: "+err.Error(), TOLOGFILE|TOCONSOLE, LEVEL_ERROR)
                 return err
             }
+            cmd.stat.rowsRead += BATCHSIZE
             flag = true
             count = 0
         }

--- a/src/log.go
+++ b/src/log.go
@@ -1,0 +1,109 @@
+/*
+copyright 2023 Qizhi Huang(flaggyellow@qq.com)
+*/
+
+package main
+
+import (
+    "log"
+    "os"
+    "path/filepath"
+    "time"
+)
+
+const (
+    TOCONSOLE = 1 << iota
+    TOLOGFILE
+)
+
+const (
+    LEVEL_DEBUG = iota
+    LEVEL_INFO
+    LEVEL_WARNING
+    LEVEL_ERROR
+)
+
+var LevelPrefixDict map[int]string = map[int]string{
+    LEVEL_INFO:    "INFO: ",
+    LEVEL_DEBUG:   "DEBUG: ",
+    LEVEL_WARNING: "WARNING: ",
+    LEVEL_ERROR:   "ERROR: ",
+}
+
+type Logger struct {
+    logDir        string
+    logName       string
+    fileWriter    *os.File
+    fileLogger    *log.Logger
+    consoleLogger *log.Logger
+    errorLogger   *log.Logger
+    debug         bool
+}
+
+func NewLogger() *Logger {
+    var err error
+    tm := time.Unix(0, time.Now().UnixNano())
+    timestr := tm.Format("2006-01-02_15-04-05")
+    filename := "migrate_log_" + timestr + ".log"
+    l := &Logger{
+        logDir:  "./logs",
+        logName: filename,
+        debug:   false,
+    }
+    logPath := filepath.Join(l.logDir, l.logName)
+
+    err = os.MkdirAll(l.logDir, os.ModePerm)
+    if err != nil {
+        log.Fatalf("ERROR: failed to create log path: %v\n", err)
+    }
+
+    l.fileWriter, err = os.OpenFile(logPath, os.O_WRONLY|os.O_CREATE, 0755)
+    if err != nil {
+        log.Fatalf("ERROR: failed to open log file: %v\n", err)
+    }
+
+    l.fileLogger = log.New(l.fileWriter, "", log.LstdFlags)
+    l.consoleLogger = log.New(os.Stdout, "", log.LstdFlags)
+    l.errorLogger = log.New(os.Stderr, "\n", 0)
+
+    return l
+}
+
+func (l *Logger) SetDebug() {
+    l.debug = true
+}
+
+func (l *Logger) IsDebug() bool {
+    return l.debug
+}
+
+func (l *Logger) LogString(str string, target int, level int) {
+    if level == LEVEL_DEBUG {
+        if !l.debug {
+            return
+        }
+    }
+    prefix := LevelPrefixDict[level]
+    if target&TOLOGFILE > 0 {
+        l.fileLogger.Println(prefix, str)
+    }
+    if target&TOCONSOLE > 0 {
+        if level < LEVEL_WARNING {
+            l.consoleLogger.Println(str)
+        } else if level >= LEVEL_WARNING {
+            l.consoleLogger.Println(prefix, str)
+        }
+    }
+}
+
+func (l *Logger) LogError(err error) {
+    l.fileLogger.Println("ERROR: ", err.Error())
+    l.errorLogger.Println("ERROR: ", err)
+}
+
+func (l *Logger) close() {
+    l.fileLogger = nil
+    l.fileWriter.Close()
+    l.consoleLogger = nil
+    l.errorLogger = nil
+}

--- a/src/main.go
+++ b/src/main.go
@@ -13,41 +13,26 @@ limitations under the License.
 package main
 
 import (
-    "fmt"
-    "io"
-    "log"
     "os"
 )
 
+var logger *Logger
+
 func main() {
-    m := NewMain()
-    if err := m.Run(os.Args[1:]...); err != nil {
-        fmt.Fprintln(os.Stderr, err)
+    logger = NewLogger()
+    defer logger.close()
+    logger.LogString("Data migrate tool starting", TOCONSOLE, LEVEL_INFO)
+    if err := Run(os.Args[1:]...); err != nil {
+        logger.LogError(err)
         os.Exit(1)
     }
 }
 
-type Main struct {
-    Logger *log.Logger
-    Stdin  io.Reader
-    Stdout io.Writer
-    Stderr io.Writer
-}
-
-func NewMain() *Main {
-    return &Main{
-        Logger: log.New(os.Stderr, "[dataMigrate] ", log.LstdFlags),
-        Stdin:  os.Stdin,
-        Stdout: os.Stdout,
-        Stderr: os.Stderr,
-    }
-}
-
-func (m *Main) Run(args ...string) error {
+func Run(args ...string) error {
     if len(args) > 0 {
         cmd := NewDataMigrateCommand()
         if err := cmd.Run(args...); err != nil {
-            return fmt.Errorf("dataMigrate: %s", err)
+            return err
         }
     }
     return nil


### PR DESCRIPTION
Resolves #7 
did things below in this commit:
1. added pprof
2. added the elapsed time and the number of rows (and tags, fields) migrated
3. added logs
4. fixed several bugs

This is what the information looks like in the console:
![图片](https://github.com/openGemini/data-migration-tools/assets/73268030/f564d356-14a1-486e-9343-c177ea45c567)
This is what the logs look like in the log file:
![图片](https://github.com/openGemini/data-migration-tools/assets/73268030/0c50f9e8-6277-4447-a9c1-8e97e0c575fe)
